### PR TITLE
fix: docker compose always restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 services:
   db:
     image: mysql:8.1
-    restart: always
+    restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: testing


### PR DESCRIPTION
La configuracion del container hacia que iniciara junto con el inicio del sistema, y que se reiniciara aun cuando se habia detenido manualmente.

Con `unless-stopped` inicia solamente cuando se requiere. 